### PR TITLE
Small corrections to tiger compiler.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,14 @@ TESTCASES=testcases
 SRC=sources.cm
 TIGERC=tigerc
 RUNTIME=runtime.s
+UNAME :-= $(shell uname -s)
+
+ifeq ($(UNAME),Linux)
+IMAGE=tigerc.x86-linux
+endif
+ifeq ($(UNAME),Darwin)
 IMAGE=tigerc.x86-darwin
+endif
 
 .PHONY: *.spim
 %.spim : %.tig ${IMAGE}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Given a tiger source program `foo.tig`, to compile it, you'll need to first copy
 the file to the project directory, and run
 
 ```
-make foo
+make foo.spim
 ```
 
 This will compile the file, append `runtime.s` to it, and generate a
@@ -51,6 +51,8 @@ run
 ```
 spim -file foo.spim
 ```
+
+If `foo.spim` exists, make will not overwrite it. You must remove the file before running make again.
 
 ### Future Work
 

--- a/env.sml
+++ b/env.sml
@@ -23,6 +23,7 @@ val base_tenv
 
 val base_funs : fun_info list =
     [("print",[T.STRING],T.UNIT),
+     ("printi",[T.INT],T.UNIT),
      ("flush",[],T.UNIT),
      ("getchar",[],T.STRING),
      ("ord",[T.STRING],T.INT),


### PR DESCRIPTION
I made some small corrections to the tiger compiler. I added printi in the top level environment (you had implemented it, but not added it to the environment). I also made a change in the Makefile to detect if it's being run on darwin or linux and selecting the correct compiler image. Finally, the README.md has instructions to compile a .spim file, but the instruction was not correct.
